### PR TITLE
Fixed the issue with tooltip on network chart displayed with offset

### DIFF
--- a/src/Tooltip.jsx
+++ b/src/Tooltip.jsx
@@ -47,6 +47,7 @@ class Tooltip extends React.Component {
         zIndex: "1",
         position: "absolute",
         pointerEvents: "none",
+        textAlign: "left"
       },
       inner: {
         display: "inline-block",


### PR DESCRIPTION
Fixed the issue where the position of tooltip in network chart is off from the actual node.

![screen shot 2017-10-05 at 3 49 32 pm](https://user-images.githubusercontent.com/25045998/31249769-9098d53c-a9e6-11e7-9c5f-cb7bb1228546.png)

@sanjaypojo @AlmahaAlmalki 

https://github.com/MacroConnections/replot-network/issues/16